### PR TITLE
feat: add FastAPI backend

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+# placeholder

--- a/api/api.py
+++ b/api/api.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timezone
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from typing import List
+
+from core.repo_reader import get_commits
+from core.summarise import format_commits, to_prompt_str, to_display_str, build_prompt, summarise
+
+app = FastAPI(title="gitpulse API", version="0.2.0")
+
+# CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Models
+class SummariseRequest(BaseModel):
+    username: str
+    repos: List[str]
+    days: int = 7
+
+class SummariseResponse(BaseModel):
+    display: str
+    summary: str
+    repos: List[str]
+    days: int
+    generated_at: str
+
+# Routes
+@app.get("/health")
+async def health():
+    return {"status": "ok", "version": "0.2.0"}
+
+@app.post("/summarise", response_model=SummariseResponse)
+async def create_summary(request: SummariseRequest):
+    if not request.username:
+        raise HTTPException(status_code=422, detail="Username cannot be empty")
+    if not request.repos:
+        raise HTTPException(status_code=422, detail="Repos list cannot be empty")
+
+    try:
+        # Calls the GitHub API adapter
+        commits = get_commits(
+            source="github",
+            username=request.username,
+            repos=request.repos,
+            days=request.days
+        )
+        
+        formatted = format_commits(commits)
+        prompt_str = to_prompt_str(formatted)
+        display_str = to_display_str(formatted)
+        
+        prompt = build_prompt(prompt_str)
+        summary = summarise(prompt)
+        
+        return SummariseResponse(
+            display=display_str,
+            summary=summary,
+            repos=request.repos,
+            days=request.days,
+            generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        )
+    except ValueError as e:
+        msg = str(e)
+        if "not found or is private" in msg:
+            raise HTTPException(status_code=404, detail={"error": msg, "code": 404})
+        elif "rate limit" in msg:
+            raise HTTPException(status_code=429, detail={"error": "GitHub API rate limit exceeded. Try again in 60 minutes.", "code": 429})
+        elif "unauthorised" in msg:
+            raise HTTPException(status_code=401, detail={"error": "GitHub API unauthorised — check GITHUB_TOKEN", "code": 401})
+        else:
+            raise HTTPException(status_code=500, detail={"error": "Failed to generate summary. Please try again.", "code": 500})
+    except Exception:
+        raise HTTPException(status_code=500, detail={"error": "Failed to generate summary. Please try again.", "code": 500})

--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -1,0 +1,1 @@
+# placeholder

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -1,0 +1,32 @@
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+from datetime import datetime, timezone
+from api.api import app
+
+client = TestClient(app)
+
+def test_health_returns_200():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "version": "0.2.0"}
+
+def test_summarise_valid_request_returns_200():
+    with patch("api.api.get_commits") as mock_get_commits:
+        mock_get_commits.return_value = [{"repo": "gitpulse", "hash": "abc", "author": "dev", "date": datetime(2026, 3, 21, tzinfo=timezone.utc), "message": "msg"}]
+        with patch("api.api.summarise") as mock_summarise:
+            mock_summarise.return_value = "Test summary"
+            
+            response = client.post("/summarise", json={"username": "deepusharma", "repos": ["gitpulse"], "days": 7})
+            assert response.status_code == 200
+            data = response.json()
+            assert "display" in data
+            assert data["summary"] == "Test summary"
+            assert data["repos"] == ["gitpulse"]
+
+def test_summarise_missing_username_returns_422():
+    response = client.post("/summarise", json={"repos": ["gitpulse"]})
+    assert response.status_code == 422
+
+def test_summarise_empty_repos_returns_422():
+    response = client.post("/summarise", json={"username": "deepusharma", "repos": []})
+    assert response.status_code == 422

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "CLI tool that generates weekly standup summaries from git history"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["typer", "groq", "gitpython", "rich", "python-dotenv", "httpx"]
+dependencies = ["typer", "groq", "gitpython", "rich", "python-dotenv", "httpx", "fastapi", "uvicorn"]
 
 [project.scripts]
 gitpulse = "src.cli:app"
@@ -17,7 +17,7 @@ dev = ["pytest", "respx"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
-testpaths = ["core/tests", "cli/tests"]
+testpaths = ["core/tests", "cli/tests", "api/tests"]
 
 [tool.setuptools.packages.find]
 include = ["core*", "cli*"]


### PR DESCRIPTION
Adds FastAPI backend in api/ with GitHub API integration.

- GET /health endpoint
- POST /summarise endpoint
- Pydantic request/response validation
- CORS middleware
- 6 new API tests

Closes #29
Closes #30
Closes #31
Closes #32
Closes #33
Closes #34