### PR TITLE
fix: use python -m uvicorn in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn api.api:app --host 0.0.0.0 --port $PORT
+web: python -m uvicorn api.api:app --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
Fixes uvicorn not found error on Railway