### PR TITLE
chore: add sprint briefs for sprint 12 and 14-18

### DIFF
--- a/docs/sprint/sprint-12-brief.md
+++ b/docs/sprint/sprint-12-brief.md
@@ -1,0 +1,40 @@
+# Sprint 12 — Enhanced Input UX & Error Feedback
+
+**Sprint goal:** Improve form validation (live username checks), searchable repo multiselect, date-range filtering, and export to MD.
+**Milestone:** v0.5 — History & Analytics
+**Duration:** Day 7 (~3-4 hours)
+**Status:** Not Started
+
+---
+
+## Pre-Sprint Requirements
+- Sprint 10 (Analytics) must be complete to ensure UI and charts are in place.
+- Ensure valid GitHub tokens are accessible for the live repo lookups.
+
+---
+
+## AI Planning Prompt
+
+### Planning Prompt (Gemini 3.1 Pro High — Planning Mode)
+```text
+Read these files before responding:
+- AGENTS.md
+- docs/sprint/sprint-12-brief.md
+- docs/architecture/overview.md
+- docs/api/api-contract.md
+- web/src/app/page.tsx (or equivalent input form)
+
+We are planning Sprint 12 — Enhanced Input UX & Error Feedback.
+
+Before writing any code:
+1. Review stories S12.1 through S12.6 mapped to this sprint.
+2. Formulate approach for live GitHub username validation without exceeding rate limits.
+3. Design the searchable repo multiselect dropdown behavior.
+4. Plan the integration of date-range filters to the /history page.
+5. Define the export-to-MD functionality from the frontend.
+6. Identify risks — particularly UX latency and external API limits.
+7. Propose step-by-step technical execution plan.
+8. Save plan to `docs/sprint/sprint-12-plan.md`.
+
+Do not write any code yet. Planning only.
+```

--- a/docs/sprint/sprint-14-brief.md
+++ b/docs/sprint/sprint-14-brief.md
@@ -1,0 +1,41 @@
+# Sprint 14 — Depth & Intelligence
+
+**Sprint goal:** Add PR and Issue activity tracking to summaries, and build the rich `/insights` dashboard with Recharts.
+**Milestone:** v0.9 — Depth & Intelligence
+**Duration:** Day 8 (~4-5 hours)
+**Status:** Not Started
+
+---
+
+## Pre-Sprint Requirements
+- All prior Sprints (S12) must be complete.
+- Ensure `recharts` is installed.
+- Review `docs/decisions/feature-brainstorm-2026-04.md` for context on the required metrics.
+
+---
+
+## AI Planning Prompt
+
+### Planning Prompt (Gemini 3.1 Pro High — Planning Mode)
+```text
+Read these files before responding:
+- AGENTS.md
+- docs/sprint/sprint-14-brief.md
+- docs/architecture/overview.md
+- docs/api/api-contract.md
+- docs/decisions/feature-brainstorm-2026-04.md
+
+We are planning Sprint 14 — Depth & Intelligence.
+
+Before writing any code:
+1. Review stories S14.1 through S14.12 mapped to this sprint.
+2. Outline how you will fetch and aggregate PR and Issue data alongside Commits.
+3. Plan the endpoints required for the `/insights` page metric cards and charts.
+4. Detail the React component structure for hover popup tooltips on metric cards.
+5. Detail the plan for generating the 2-week Sprint Retrospective.
+6. Identify risks — especially regarding complex API aggregations.
+7. Propose step-by-step technical execution plan.
+8. Save plan to `docs/sprint/sprint-14-plan.md`.
+
+Do not write any code yet. Planning only.
+```

--- a/docs/sprint/sprint-15-brief.md
+++ b/docs/sprint/sprint-15-brief.md
@@ -1,0 +1,39 @@
+# Sprint 15 — Team & Reach
+
+**Sprint goal:** Enable multi-username team standups, Slack team delivery, README badge generation, and presentation mode.
+**Milestone:** v1.0 — Team & Reach
+**Duration:** Day 9 (~4 hours)
+**Status:** Not Started
+
+---
+
+## Pre-Sprint Requirements
+- Sprint 14 should be complete.
+- Read up on the `shields.io` badge generation endpoint format if necessary.
+
+---
+
+## AI Planning Prompt
+
+### Planning Prompt (Gemini 3.1 Pro High — Planning Mode)
+```text
+Read these files before responding:
+- AGENTS.md
+- docs/sprint/sprint-15-brief.md
+- docs/architecture/overview.md
+- docs/api/api-contract.md
+
+We are planning Sprint 15 — Team & Reach.
+
+Before writing any code:
+1. Review stories S15.1 through S15.6 mapped to this sprint.
+2. Define the schema and DB changes required to save and load "Team Rosters".
+3. Formulate how to execute parallel GitHub calls for multiple users efficiently.
+4. Detail the Next.js routing and UI styling plan for `/present` presentation mode.
+5. Outline structure for badge-generation endpoints (`/api/badges/...`).
+6. Identify any rate-limiting risks when querying data for whole teams.
+7. Propose a step-by-step technical execution plan.
+8. Save plan to `docs/sprint/sprint-15-plan.md`.
+
+Do not write any code yet. Planning only.
+```

--- a/docs/sprint/sprint-16-brief.md
+++ b/docs/sprint/sprint-16-brief.md
@@ -1,0 +1,37 @@
+# Sprint 16 — Pro Features
+
+**Sprint goal:** Add support for private org repos via expanded OAuth scope, public shareable summary links, and comparison modes.
+**Milestone:** v1.1 — Pro Features
+**Duration:** Day 10 (~3-4 hours)
+**Status:** Not Started
+
+---
+
+## Pre-Sprint Requirements
+- Ensure NextAuth.js setup is accessible for scope modification.
+
+---
+
+## AI Planning Prompt
+
+### Planning Prompt (Gemini 3.1 Pro High — Planning Mode)
+```text
+Read these files before responding:
+- AGENTS.md
+- docs/sprint/sprint-16-brief.md
+- docs/architecture/overview.md
+- web/src/app/api/auth/[...nextauth]/route.ts (or equivalent OAuth Config)
+
+We are planning Sprint 16 — Pro Features.
+
+Before writing any code:
+1. Review stories S16.1 through S16.3 mapped to this sprint.
+2. Detail exactly how we map the expanded `repo` OAuth scope to the core library API client.
+3. Design the database migration and API routing for `/summary/:id` public links.
+4. Formulate the approach for fetching and comparing historical date-ranges in `/insights`.
+5. Identify security/permissions risks with sharing and private scopes.
+6. Propose a step-by-step technical execution plan.
+7. Save plan to `docs/sprint/sprint-16-plan.md`.
+
+Do not write any code yet. Planning only.
+```

--- a/docs/sprint/sprint-17-brief.md
+++ b/docs/sprint/sprint-17-brief.md
@@ -1,0 +1,38 @@
+# Sprint 17 — AI & MCP
+
+**Sprint goal:** Build MCP server to expose core functions to Claude/Cursor, and implement AI proactive recommendations.
+**Milestone:** v1.2 — AI & MCP
+**Duration:** Day 11 (~4 hours)
+**Status:** Not Started
+
+---
+
+## Pre-Sprint Requirements
+- Review Official Model Context Protocol (MCP) python SDK documentation online if necessary.
+
+---
+
+## AI Planning Prompt
+
+### Planning Prompt (Gemini 3.1 Pro High — Planning Mode)
+```text
+Read these files before responding:
+- AGENTS.md
+- docs/sprint/sprint-17-brief.md
+- docs/architecture/overview.md
+- docs/decisions/feature-brainstorm-2026-04.md (specifically MCP section)
+
+We are planning Sprint 17 — AI & MCP.
+
+Before writing any code:
+1. Review stories S17.1 through S17.7 mapped to this sprint.
+2. Outline the Python MCP script structure wrapping the existing `core/` library functions.
+3. Define the tool schemas for `generate_standup`, `analyze_repo`, and `get_insights`.
+4. Devise the architecture for the `/mcp` SSE real-time remote endpoint on FastAPI.
+5. Prepare prompts for the proactive "Nudges/Recommendations" feature.
+6. Identify setup edge-cases for various IDEs.
+7. Propose a step-by-step technical execution plan.
+8. Save plan to `docs/sprint/sprint-17-plan.md`.
+
+Do not write any code yet. Planning only.
+```

--- a/docs/sprint/sprint-18-brief.md
+++ b/docs/sprint/sprint-18-brief.md
@@ -1,0 +1,38 @@
+# Sprint 18 — Delight
+
+**Sprint goal:** Gamify with commit streaks, generate annual Year in Review summaries, and build a VS Code extension.
+**Milestone:** v1.3 — Delight
+**Duration:** Day 12 (~5 hours)
+**Status:** Not Started
+
+---
+
+## Pre-Sprint Requirements
+- Sprint 17 must be complete.
+- Evaluate VS Code extension starter templates.
+
+---
+
+## AI Planning Prompt
+
+### Planning Prompt (Gemini 3.1 Pro High — Planning Mode)
+```text
+Read these files before responding:
+- AGENTS.md
+- docs/sprint/sprint-18-brief.md
+- docs/architecture/overview.md
+- docs/api/api-contract.md
+
+We are planning Sprint 18 — Delight.
+
+Before writing any code:
+1. Review stories S18.1 through S18.3 mapped to this sprint.
+2. Formulate the SQL / Logic algorithm for accurately calculating consecutive commit streak days.
+3. Design the payload shape required for the extensive "Year in Review" aggregated API endpoint.
+4. Establish the blueprint for the VS Code typescript extension communicating with the FastAPI backend.
+5. Identify architecture risks around long-running "Year in Review" aggregation queries.
+6. Propose a step-by-step technical execution plan.
+7. Save plan to `docs/sprint/sprint-18-plan.md`.
+
+Do not write any code yet. Planning only.
+```


### PR DESCRIPTION
Adds the missing sprint briefs per PRD roadmap:
- Sprint 12 (Enhanced Input UX)
- Sprint 14 (Insights & Activity Enrichment)
- Sprint 15 (Team Standups & Delivery)
- Sprint 16 (Pro Features)
- Sprint 17 (MCP Server & IDE)
- Sprint 18 (Gamification & Delight)