### PR TITLE
docs: flesh out sprint briefs 12-18 with execution streams and story details

### DIFF
--- a/docs/sprint/sprint-12-brief.md
+++ b/docs/sprint/sprint-12-brief.md
@@ -22,19 +22,89 @@ Read these files before responding:
 - docs/sprint/sprint-12-brief.md
 - docs/architecture/overview.md
 - docs/api/api-contract.md
-- web/src/app/page.tsx (or equivalent input form)
 
 We are planning Sprint 12 — Enhanced Input UX & Error Feedback.
 
 Before writing any code:
-1. Review stories S12.1 through S12.6 mapped to this sprint.
-2. Formulate approach for live GitHub username validation without exceeding rate limits.
-3. Design the searchable repo multiselect dropdown behavior.
-4. Plan the integration of date-range filters to the /history page.
-5. Define the export-to-MD functionality from the frontend.
-6. Identify risks — particularly UX latency and external API limits.
-7. Propose step-by-step technical execution plan.
-8. Save plan to `docs/sprint/sprint-12-plan.md`.
+1. Review stories S12.1–S12.6
+2. Plan API wrapper for live GitHub username/repo validation
+3. Plan React component for searchable multiselect
+4. Propose step-by-step execution plan
+5. Save plan to docs/sprint/sprint-12-plan.md
 
-Do not write any code yet. Planning only.
+Do not write code yet. Planning only.
 ```
+
+### Execution Prompt — Stream 1: GitHub API Validation & UI
+```text
+Execute Stream 1 — live validation and multiselect.
+Branch: feature/sprint-12-input-ux
+
+Use @frontend-dev and @backend-dev.
+- Build /api/github/validate-user endpoints
+- Build searchable repo multiselect component in Next.js
+- Handle repo-specific 404 messages.
+
+Commit and push.
+```
+
+### Execution Prompt — Stream 2: History Filters & Export
+```text
+Execute Stream 2 — filters and export.
+Still on branch: feature/sprint-12-input-ux
+
+- Add search and date-range controls to /history
+- Build Markdown export function returning downloadable .md
+- Add commit activity stats footer matching summary.
+
+Commit, push, create PR.
+```
+
+---
+
+## Sprint Stories
+
+| Issue | Story | Status | Priority |
+|---|---|---|---|
+| #137 | S12.1: Surface repo-specific 404 message | 🔵 This Sprint | High |
+| #138 | S12.2: Validate GitHub username live | 🔵 This Sprint | High |
+| #139 | S12.3: Searchable repo multiselect dropdown | 🔵 This Sprint | High |
+| #140 | S12.4: Commit activity stats footer | 🔵 This Sprint | Medium |
+| #141 | S12.5: Search and date-range filters | 🔵 This Sprint | Medium |
+| #142 | S12.6: Export standup as .md file | 🔵 This Sprint | Low |
+
+---
+
+## Story Details & Definition of Done
+
+### #137 & #138 & #139 — Form Validation & Multiselect
+**UI:**
+- Live typing debounce for username check.
+- Shows green checkmark if valid.
+- Searchable dropdown fetches user repos.
+**Done when:**
+- [ ] Username validates instantly.
+- [ ] Repo multiselect accurately searches GitHub API.
+- [ ] Specific 404 errors are bubbled up gracefully.
+
+### #140 & #141 & #142 — History Filters & Export
+**UI:**
+- Date picker and search bar on `/history`.
+- Export button on specific summary views.
+**Done when:**
+- [ ] Filter updates list in real-time.
+- [ ] Export generates valid `.md` file download.
+
+---
+
+## New API Endpoints Needed
+```python
+GET /github/validate?username=X
+# Returns {"valid": true, "avatar_url": "..."}
+
+GET /github/repos?username=X&search=Y
+# Returns [{"name": "repo1"}, ...]
+```
+
+## Order of Work
+Validation API → Multiselect UI → Filter UI → Export Button

--- a/docs/sprint/sprint-14-brief.md
+++ b/docs/sprint/sprint-14-brief.md
@@ -28,14 +28,78 @@ Read these files before responding:
 We are planning Sprint 14 — Depth & Intelligence.
 
 Before writing any code:
-1. Review stories S14.1 through S14.12 mapped to this sprint.
+1. Review stories S14.1 through S14.11 mapped to this sprint.
 2. Outline how you will fetch and aggregate PR and Issue data alongside Commits.
 3. Plan the endpoints required for the `/insights` page metric cards and charts.
-4. Detail the React component structure for hover popup tooltips on metric cards.
-5. Detail the plan for generating the 2-week Sprint Retrospective.
-6. Identify risks — especially regarding complex API aggregations.
-7. Propose step-by-step technical execution plan.
-8. Save plan to `docs/sprint/sprint-14-plan.md`.
+4. Propose step-by-step technical execution plan.
+5. Save plan to `docs/sprint/sprint-14-plan.md`.
 
 Do not write any code yet. Planning only.
 ```
+
+### Execution Prompt — Stream 1: PR/Issue Enrichment
+```text
+Execute Stream 1 — PR/Issue enrichment in core summarization.
+Branch: feature/sprint-14-depth
+
+Use @backend-dev.
+- Update GitHub API calls to fetch PRs (opened/merged/reviewed) and Issues (opened/closed).
+- Update the core Markdown generator to include these new sections.
+- Create 2-week Sprint Retrospective prompt mode.
+
+Commit and push.
+```
+
+### Execution Prompt — Stream 2: Insights UI Dashboard
+```text
+Execute Stream 2 — /insights dashboard.
+Still on branch: feature/sprint-14-depth
+
+Use @frontend-dev.
+- Build /insights page with metric cards utilizing recharts (bar charts, line charts).
+- Include hover popovers for drill-down tooltips.
+- Add "Stats for Nerds" panel.
+
+Commit, push, create PR.
+```
+
+---
+
+## Sprint Stories
+
+| Issue | Story | Status | Priority |
+|---|---|---|---|
+| TBD | S14.1: PR activity in standup summary | 🔵 This Sprint | High |
+| TBD | S14.2: Issue activity in standup summary | 🔵 This Sprint | High |
+| TBD | S14.3: GitHub Projects sprint card activity | 🔵 This Sprint | Medium |
+| TBD | S14.4: AI-powered sprint retrospective | 🔵 This Sprint | High |
+| TBD | S14.5: Metric cards for /insights | 🔵 This Sprint | High |
+| TBD | S14.6: Advanced Recharts (Velocity/Health area charts) | 🔵 This Sprint | Medium |
+| TBD | S14.7: Language breakdown donut chart & badges | 🔵 This Sprint | Low |
+| TBD | S14.8: Repo metadata panel (stars, forks, CI) | 🔵 This Sprint | Medium |
+| TBD | S14.9: Repo health score algorithm | 🔵 This Sprint | Low |
+| TBD | S14.10: Stats for Nerds panel | 🔵 This Sprint | Low |
+| TBD | S14.11: Date range and repo filters on /insights | 🔵 This Sprint | Medium |
+
+---
+
+## Story Details & Definition of Done
+
+### PR & Issue Parsing (S14.1-S14.3)
+**Data source:** GitHub GraphQL or REST (Pulls & Issues).
+**Done when:**
+- [ ] Summaries include properly formatted lists of reviewed PRs.
+- [ ] Closed issues are linked with # references.
+
+### Insights Dashboard (S14.5-S14.11)
+**UI:**
+- Modern dashboard with grid layout.
+- Hover popovers explicitly capped at 8 items.
+**Done when:**
+- [ ] /insights renders correctly without hydration errors.
+- [ ] Charts populate via backend endpoints.
+
+---
+
+## Order of Work
+Core Python Fetchers → Markdown Updater → Insights API → React Dashboard

--- a/docs/sprint/sprint-15-brief.md
+++ b/docs/sprint/sprint-15-brief.md
@@ -9,7 +9,7 @@
 
 ## Pre-Sprint Requirements
 - Sprint 14 should be complete.
-- Read up on the `shields.io` badge generation endpoint format if necessary.
+- Slack Webhook URL required for end-to-end testing.
 
 ---
 
@@ -26,14 +26,72 @@ Read these files before responding:
 We are planning Sprint 15 — Team & Reach.
 
 Before writing any code:
-1. Review stories S15.1 through S15.6 mapped to this sprint.
-2. Define the schema and DB changes required to save and load "Team Rosters".
-3. Formulate how to execute parallel GitHub calls for multiple users efficiently.
-4. Detail the Next.js routing and UI styling plan for `/present` presentation mode.
-5. Outline structure for badge-generation endpoints (`/api/badges/...`).
-6. Identify any rate-limiting risks when querying data for whole teams.
-7. Propose a step-by-step technical execution plan.
-8. Save plan to `docs/sprint/sprint-15-plan.md`.
+1. Review stories S15.1 through S15.6.
+2. Define the schema to save/load "Team Rosters".
+3. Plan Next.js `/present` presentation mode.
+4. Outline structure for badge-generation endpoints (`/badges/*`).
+5. Propose a step-by-step technical execution plan.
+6. Save plan to `docs/sprint/sprint-15-plan.md`.
 
-Do not write any code yet. Planning only.
+Do not write code yet. Planning only.
 ```
+
+### Execution Prompt — Stream 1: Team Rosters & Summary
+```text
+Execute Stream 1 — Team logic.
+Branch: feature/sprint-15-team
+
+Use @backend-dev.
+- Update the API to accept multiple usernames.
+- Build Team Roster CRUD endpoints.
+- Map generated aggregations for Slack webhook delivery.
+
+Commit and push.
+```
+
+### Execution Prompt — Stream 2: Presentation & Badges
+```text
+Execute Stream 2 — Reach and UI.
+Still on branch: feature/sprint-15-team
+
+Use @frontend-dev.
+- Add /present view for screen-share standups (large typography, carousel).
+- Build the `/badges/` endpoint returning SVG or redirecting to shields.io.
+
+Commit, push, create PR.
+```
+
+---
+
+## Sprint Stories
+
+| Issue | Story | Status | Priority |
+|---|---|---|---|
+| TBD | S15.1: Multi-username team standup | 🔵 This Sprint | High |
+| TBD | S15.2: Team roster management (save/load) | 🔵 This Sprint | Medium |
+| TBD | S15.3: Slack channel team delivery | 🔵 This Sprint | High |
+| TBD | S15.4: README badge generator | 🔵 This Sprint | Low |
+| TBD | S15.5: Presentation mode (`/present`) | 🔵 This Sprint | Medium |
+| TBD | S15.6: Smart reminders for standups | 🔵 This Sprint | Low |
+
+---
+
+## Story Details & Definition of Done
+
+### Team Standups & Slack (S15.1-S15.3)
+**Data source:** existing core aggregator, mapped over list of users.
+**Done when:**
+- [ ] Users can enter multiple commas separated usernames or save them as a roster.
+- [ ] API can post the aggregated standup blocks to a configurable Slack channel.
+
+### Present & Badges (S15.4-S15.5)
+**UI:**
+- Present mode strips out sidebars and uses pure markdown typography scaled up 150%.
+**Done when:**
+- [ ] Present mode scales with viewport.
+- [ ] Badges successfully render streak counts via simple HTTP GET.
+
+---
+
+## Order of Work
+Roster CRUD → Core Multi-User Aggregator → Slack Integration → Present UI → Badges API

--- a/docs/sprint/sprint-16-brief.md
+++ b/docs/sprint/sprint-16-brief.md
@@ -20,18 +20,72 @@ Read these files before responding:
 - AGENTS.md
 - docs/sprint/sprint-16-brief.md
 - docs/architecture/overview.md
-- web/src/app/api/auth/[...nextauth]/route.ts (or equivalent OAuth Config)
+- web/src/app/api/auth/[...nextauth]/route.ts
 
 We are planning Sprint 16 — Pro Features.
 
 Before writing any code:
-1. Review stories S16.1 through S16.3 mapped to this sprint.
-2. Detail exactly how we map the expanded `repo` OAuth scope to the core library API client.
-3. Design the database migration and API routing for `/summary/:id` public links.
-4. Formulate the approach for fetching and comparing historical date-ranges in `/insights`.
-5. Identify security/permissions risks with sharing and private scopes.
-6. Propose a step-by-step technical execution plan.
-7. Save plan to `docs/sprint/sprint-16-plan.md`.
+1. Review stories S16.1 through S16.3.
+2. Detail how we map the expanded `repo` OAuth scope to the core library API client.
+3. Design the database backend for `/summary/:id` public links.
+4. Propose a step-by-step technical execution plan.
+5. Save plan to `docs/sprint/sprint-16-plan.md`.
 
-Do not write any code yet. Planning only.
+Do not write code yet. Planning only.
 ```
+
+### Execution Prompt — Stream 1: Private Repos & OAuth
+```text
+Execute Stream 1 — OAuth scoped access.
+Branch: feature/sprint-16-pro
+
+Use @backend-dev and @frontend-dev.
+- Update NextAuth to request `repo` scope when needed.
+- Surface permission toggles to users before redirecting to GitHub.
+- Ensure API passes token to fetch private org commits.
+
+Commit and push.
+```
+
+### Execution Prompt — Stream 2: Shareable Links & Comparisons
+```text
+Execute Stream 2 — Public links.
+Still on branch: feature/sprint-16-pro
+
+- Implement DB flags for `is_public` on summaries.
+- Build `/summary/:id` unauthenticated React page.
+- Add historical comparison data overlays to `/insights`.
+
+Commit, push, create PR.
+```
+
+---
+
+## Sprint Stories
+
+| Issue | Story | Status | Priority |
+|---|---|---|---|
+| TBD | S16.1: Support private org repos via expanded OAuth | 🔵 This Sprint | High |
+| TBD | S16.2: Shareable public DB links (`/summary/:id`) | 🔵 This Sprint | High |
+| TBD | S16.3: Comparison mode (this period vs last period) | 🔵 This Sprint | Medium |
+
+---
+
+## Story Details & Definition of Done
+
+### Private Repos (S16.1)
+**Done when:**
+- [ ] Users can opt-in to private repo access.
+- [ ] Application securely fetches commits from repos otherwise inaccessible to public APIs.
+
+### Public Links & Comparisions (S16.2-S16.3)
+**UI:**
+- Share button automatically copies unique UUID permalink.
+**Done when:**
+- [ ] `/summary/:id` page resolves without Auth if marked public.
+- [ ] Trends show red/green arrows based on previous periods.
+
+---
+
+## Order of Work
+OAuth Scope Upgrade → Private API Verify → DB Public Flags → React Unauth Page → Trend Math

--- a/docs/sprint/sprint-17-brief.md
+++ b/docs/sprint/sprint-17-brief.md
@@ -1,6 +1,6 @@
 # Sprint 17 — AI & MCP
 
-**Sprint goal:** Build MCP server to expose core functions to Claude/Cursor, and implement AI proactive recommendations.
+**Sprint goal:** Build MCP server exposing core functions to Claude/Cursor, and implement AI proactive recommendations.
 **Milestone:** v1.2 — AI & MCP
 **Duration:** Day 11 (~4 hours)
 **Status:** Not Started
@@ -8,7 +8,8 @@
 ---
 
 ## Pre-Sprint Requirements
-- Review Official Model Context Protocol (MCP) python SDK documentation online if necessary.
+- Familiarity with the official Model Context Protocol (MCP) specifications.
+- Environment with Claude Desktop or Cursor for local testing.
 
 ---
 
@@ -20,19 +21,75 @@ Read these files before responding:
 - AGENTS.md
 - docs/sprint/sprint-17-brief.md
 - docs/architecture/overview.md
-- docs/decisions/feature-brainstorm-2026-04.md (specifically MCP section)
+- docs/decisions/feature-brainstorm-2026-04.md
 
 We are planning Sprint 17 — AI & MCP.
 
 Before writing any code:
-1. Review stories S17.1 through S17.7 mapped to this sprint.
-2. Outline the Python MCP script structure wrapping the existing `core/` library functions.
-3. Define the tool schemas for `generate_standup`, `analyze_repo`, and `get_insights`.
-4. Devise the architecture for the `/mcp` SSE real-time remote endpoint on FastAPI.
-5. Prepare prompts for the proactive "Nudges/Recommendations" feature.
-6. Identify setup edge-cases for various IDEs.
-7. Propose a step-by-step technical execution plan.
-8. Save plan to `docs/sprint/sprint-17-plan.md`.
+1. Review stories S17.1 through S17.7.
+2. Outline the Python MCP script structure wrapping the existing `core/` functions.
+3. Define the tool JSON schemas.
+4. Propose a step-by-step technical execution plan.
+5. Save plan to `docs/sprint/sprint-17-plan.md`.
 
-Do not write any code yet. Planning only.
+Do not write code yet. Planning only.
 ```
+
+### Execution Prompt — Stream 1: MCP Server Core
+```text
+Execute Stream 1 — MCP Protocol Server.
+Branch: feature/sprint-17-local-mcp
+
+Use @backend-dev.
+- Build `mcp/server.py` implementing stdio MCP wrappers around core library.
+- Expose `generate_standup` and `get_insights` as precise tools.
+
+Commit and push.
+```
+
+### Execution Prompt — Stream 2: Web Integration
+```text
+Execute Stream 2 — IDE Integrations & Proactive AI.
+Still on branch: feature/sprint-17-local-mcp
+
+- Map SSE real-time remote endpoint on FastAPI.
+- Add AI proactive recommendations module generating dynamic insight prompts.
+- Document `/docs/mcp` configuration blocks.
+
+Commit, push, create PR.
+```
+
+---
+
+## Sprint Stories
+
+| Issue | Story | Status | Priority |
+|---|---|---|---|
+| TBD | S17.1: Build `mcp/server.py` wrapping core | 🔵 This Sprint | High |
+| TBD | S17.2: Expose MCP JSON tool schemas | 🔵 This Sprint | High |
+| TBD | S17.3: Publish MCP server to PyPI | 🔵 This Sprint | Medium |
+| TBD | S17.4: FastAPI SSE MCP proxy | 🔵 This Sprint | Medium |
+| TBD | S17.5: Document MCP IDE setup | 🔵 This Sprint | Low |
+| TBD | S17.6: AI proactive recommendations | 🔵 This Sprint | Medium |
+| TBD | S17.7: Saved prompt templates | 🔵 This Sprint | Low |
+
+---
+
+## Story Details & Definition of Done
+
+### MCP Protocol Setup (S17.1-S17.5)
+**Architecture:** Python `mcp` pip package using `stdio` transport.
+**Done when:**
+- [ ] Users can add `uv run mcp/server.py` to their `claude_desktop_config.json`.
+- [ ] LLM inside IDE can request commit data and write standups automatically.
+
+### AI Customization (S17.6-S17.7)
+**UI:**
+- Insights page displays a sidebar block with "AI Notice" suggestions based on anomalies.
+**Done when:**
+- [ ] LLM automatically identifies "unusually high PR cycle time".
+
+---
+
+## Order of Work
+MCP Protocol → Server Functions → Testing via Claude Desktop → Proactive AI Gen → Documentation

--- a/docs/sprint/sprint-18-brief.md
+++ b/docs/sprint/sprint-18-brief.md
@@ -9,7 +9,7 @@
 
 ## Pre-Sprint Requirements
 - Sprint 17 must be complete.
-- Evaluate VS Code extension starter templates.
+- Verify node/npm tooling for VS Code extension building.
 
 ---
 
@@ -21,18 +21,72 @@ Read these files before responding:
 - AGENTS.md
 - docs/sprint/sprint-18-brief.md
 - docs/architecture/overview.md
-- docs/api/api-contract.md
 
 We are planning Sprint 18 — Delight.
 
 Before writing any code:
-1. Review stories S18.1 through S18.3 mapped to this sprint.
-2. Formulate the SQL / Logic algorithm for accurately calculating consecutive commit streak days.
-3. Design the payload shape required for the extensive "Year in Review" aggregated API endpoint.
-4. Establish the blueprint for the VS Code typescript extension communicating with the FastAPI backend.
-5. Identify architecture risks around long-running "Year in Review" aggregation queries.
-6. Propose a step-by-step technical execution plan.
-7. Save plan to `docs/sprint/sprint-18-plan.md`.
+1. Review stories S18.1 through S18.3.
+2. Outline the logic for accurately calculating commit streak days.
+3. Design the schema for the "Year in Review" aggregator endpoint.
+4. Establish the blueprint for integrating the VS Code extension sidebar.
+5. Propose a step-by-step technical execution plan.
+6. Save plan to `docs/sprint/sprint-18-plan.md`.
 
-Do not write any code yet. Planning only.
+Do not write code yet. Planning only.
 ```
+
+### Execution Prompt — Stream 1: Gamification & Year-in-Review
+```text
+Execute Stream 1 — Core data delights.
+Branch: feature/sprint-18-delight
+
+Use @backend-dev.
+- Build SQL optimized streak calculators.
+- Create `/api/year-in-review` endpoint.
+- Render special Year in Review celebration UI in Next.js.
+
+Commit and push.
+```
+
+### Execution Prompt — Stream 2: VS Code Extension
+```text
+Execute Stream 2 — IDE extension sidebar.
+Still on branch: feature/sprint-18-delight
+
+Use @frontend-dev.
+- Scaffold VS Code webview extension.
+- Integrate fetching from local or remote GitPulse API.
+
+Commit, push, create PR.
+```
+
+---
+
+## Sprint Stories
+
+| Issue | Story | Status | Priority |
+|---|---|---|---|
+| TBD | S18.1: Commit streak tracking & personal bests | 🔵 This Sprint | High |
+| TBD | S18.2: Generate annual Year in Review | 🔵 This Sprint | High |
+| TBD | S18.3: VS Code extension sidebar | 🔵 This Sprint | Medium |
+
+---
+
+## Story Details & Definition of Done
+
+### Gamification (S18.1-S18.2)
+**Data source:** SQL query counting localized consecutive days with `commit_count > 0`.
+**Done when:**
+- [ ] Streak badges correctly ignore weekends (optional setting).
+- [ ] Year in Review groups data by month and generates "Spotify Wrapped" style UI.
+
+### VS Code Extension (S18.3)
+**Architecture:** Typescript `vscode-extension` boilerplate utilizing React webview.
+**Done when:**
+- [ ] Plugin runs in local VS Code.
+- [ ] Displays summarized standup view directly in sidebar without leaving editor.
+
+---
+
+## Order of Work
+Streak SQL → Year-in-Review Endpoint → Celebration UI → VS Code Scaffold


### PR DESCRIPTION
Following the detailed planning template from Sprint 10, this PR fleshes out the newly created sprint briefs for sprints 12, 14, 15, 16, 17, and 18. Each brief now includes:
- Execution stream prompts broken down for frontend/backend
- Sprint Stories table with issue tracking and priority
- Story Details and explicit 'Done when' criteria
- New API endpoint shapes and Order of Work lists