### PR TITLE
docs: align sprint brief templates to match v0.5 standard

### DIFF
--- a/docs/sprint/sprint-12-brief.md
+++ b/docs/sprint/sprint-12-brief.md
@@ -16,7 +16,7 @@
 ## AI Planning Prompt
 
 ### Planning Prompt (Gemini 3.1 Pro High — Planning Mode)
-```text
+```
 Read these files before responding:
 - AGENTS.md
 - docs/sprint/sprint-12-brief.md
@@ -36,7 +36,7 @@ Do not write code yet. Planning only.
 ```
 
 ### Execution Prompt — Stream 1: GitHub API Validation & UI
-```text
+```
 Execute Stream 1 — live validation and multiselect.
 Branch: feature/sprint-12-input-ux
 
@@ -49,10 +49,11 @@ Commit and push.
 ```
 
 ### Execution Prompt — Stream 2: History Filters & Export
-```text
+```
 Execute Stream 2 — filters and export.
 Still on branch: feature/sprint-12-input-ux
 
+Use @frontend-dev.
 - Add search and date-range controls to /history
 - Build Markdown export function returning downloadable .md
 - Add commit activity stats footer matching summary.
@@ -75,22 +76,32 @@ Commit, push, create PR.
 
 ---
 
-## Story Details & Definition of Done
+## Story Details
 
-### #137 & #138 & #139 — Form Validation & Multiselect
+### #137, #138, #139 — Form Validation & Multiselect
+
+**Data source:** GitHub REST API.
+
 **UI:**
 - Live typing debounce for username check.
 - Shows green checkmark if valid.
 - Searchable dropdown fetches user repos.
+
 **Done when:**
-- [ ] Username validates instantly.
+- [ ] Username validates instantly via `/github/validate`.
 - [ ] Repo multiselect accurately searches GitHub API.
 - [ ] Specific 404 errors are bubbled up gracefully.
 
-### #140 & #141 & #142 — History Filters & Export
+---
+
+### #140, #141, #142 — History Filters & Export
+
+**Data source:** Local PostgreSQL summaries.
+
 **UI:**
 - Date picker and search bar on `/history`.
 - Export button on specific summary views.
+
 **Done when:**
 - [ ] Filter updates list in real-time.
 - [ ] Export generates valid `.md` file download.
@@ -98,6 +109,7 @@ Commit, push, create PR.
 ---
 
 ## New API Endpoints Needed
+
 ```python
 GET /github/validate?username=X
 # Returns {"valid": true, "avatar_url": "..."}
@@ -106,5 +118,19 @@ GET /github/repos?username=X&search=Y
 # Returns [{"name": "repo1"}, ...]
 ```
 
+---
+
 ## Order of Work
+```text
 Validation API → Multiselect UI → Filter UI → Export Button
+```
+
+---
+
+## Definition of Done
+- [ ] Validation API endpoints working
+- [ ] Frontend multiselect component renders and interacts
+- [ ] History search and filters work
+- [ ] Standup export functions properly
+- [ ] All tests pass
+- [ ] PR merged

--- a/docs/sprint/sprint-14-brief.md
+++ b/docs/sprint/sprint-14-brief.md
@@ -17,7 +17,7 @@
 ## AI Planning Prompt
 
 ### Planning Prompt (Gemini 3.1 Pro High — Planning Mode)
-```text
+```
 Read these files before responding:
 - AGENTS.md
 - docs/sprint/sprint-14-brief.md
@@ -38,7 +38,7 @@ Do not write any code yet. Planning only.
 ```
 
 ### Execution Prompt — Stream 1: PR/Issue Enrichment
-```text
+```
 Execute Stream 1 — PR/Issue enrichment in core summarization.
 Branch: feature/sprint-14-depth
 
@@ -51,7 +51,7 @@ Commit and push.
 ```
 
 ### Execution Prompt — Stream 2: Insights UI Dashboard
-```text
+```
 Execute Stream 2 — /insights dashboard.
 Still on branch: feature/sprint-14-depth
 
@@ -83,23 +83,58 @@ Commit, push, create PR.
 
 ---
 
-## Story Details & Definition of Done
+## Story Details
 
 ### PR & Issue Parsing (S14.1-S14.3)
+
 **Data source:** GitHub GraphQL or REST (Pulls & Issues).
+
+**UI:**
+- Included natively in Markdown outputs.
+
 **Done when:**
 - [ ] Summaries include properly formatted lists of reviewed PRs.
 - [ ] Closed issues are linked with # references.
 
+---
+
 ### Insights Dashboard (S14.5-S14.11)
+
+**Data source:** `GET /insights/...` aggregation endpoints.
+**Library:** recharts
+
 **UI:**
 - Modern dashboard with grid layout.
 - Hover popovers explicitly capped at 8 items.
+
 **Done when:**
 - [ ] /insights renders correctly without hydration errors.
 - [ ] Charts populate via backend endpoints.
 
 ---
 
+## New API Endpoints Needed
+
+```python
+GET /insights/metrics?username=X
+# Returns aggregated PR and commit velocity
+GET /insights/health?username=X
+# Returns computed health score
+```
+
+---
+
 ## Order of Work
+```text
 Core Python Fetchers → Markdown Updater → Insights API → React Dashboard
+```
+
+---
+
+## Definition of Done
+- [ ] Core fetcher supports PRs and Issues
+- [ ] Generated Markdown includes activity sections
+- [ ] Insights API endpoints return correct datasets
+- [ ] /insights components render recharts appropriately
+- [ ] All tests pass
+- [ ] PR merged

--- a/docs/sprint/sprint-15-brief.md
+++ b/docs/sprint/sprint-15-brief.md
@@ -16,7 +16,7 @@
 ## AI Planning Prompt
 
 ### Planning Prompt (Gemini 3.1 Pro High — Planning Mode)
-```text
+```
 Read these files before responding:
 - AGENTS.md
 - docs/sprint/sprint-15-brief.md
@@ -37,7 +37,7 @@ Do not write code yet. Planning only.
 ```
 
 ### Execution Prompt — Stream 1: Team Rosters & Summary
-```text
+```
 Execute Stream 1 — Team logic.
 Branch: feature/sprint-15-team
 
@@ -50,7 +50,7 @@ Commit and push.
 ```
 
 ### Execution Prompt — Stream 2: Presentation & Badges
-```text
+```
 Execute Stream 2 — Reach and UI.
 Still on branch: feature/sprint-15-team
 
@@ -76,22 +76,61 @@ Commit, push, create PR.
 
 ---
 
-## Story Details & Definition of Done
+## Story Details
 
 ### Team Standups & Slack (S15.1-S15.3)
+
 **Data source:** existing core aggregator, mapped over list of users.
+
+**UI:**
+- Roster management configuration module.
+- "Send to Slack" toggle.
+
 **Done when:**
-- [ ] Users can enter multiple commas separated usernames or save them as a roster.
+- [ ] Users can enter multiple comma separated usernames or save roster.
 - [ ] API can post the aggregated standup blocks to a configurable Slack channel.
 
+---
+
 ### Present & Badges (S15.4-S15.5)
+
+**Data source:** Aggregated Standup response payload.
+
 **UI:**
-- Present mode strips out sidebars and uses pure markdown typography scaled up 150%.
+- Present mode strips sidebars and scales typography to 150%.
+- Carousel for scrolling through team members.
+
 **Done when:**
-- [ ] Present mode scales with viewport.
-- [ ] Badges successfully render streak counts via simple HTTP GET.
+- [ ] Present mode scales with viewport without breaking.
+- [ ] Badges explicitly render streak counts via simple HTTP GET response.
+
+---
+
+## New API Endpoints Needed
+
+```python
+POST /team/roster
+# Save a list of team members
+POST /deliver/slack
+# Deliver generated standup via webhook
+GET /badges/streak?username=X
+# Returns SVG or badge proxy data
+```
 
 ---
 
 ## Order of Work
+```text
 Roster CRUD → Core Multi-User Aggregator → Slack Integration → Present UI → Badges API
+```
+
+---
+
+## Definition of Done
+- [ ] API accepts multiple usernames and aggregates properly
+- [ ] Team Roster is creatable and savable
+- [ ] Slack webhook payload correctly formatted
+- [ ] `/present` mode renders without standard layouts
+- [ ] Badges API functional
+- [ ] All tests pass
+- [ ] PR merged

--- a/docs/sprint/sprint-16-brief.md
+++ b/docs/sprint/sprint-16-brief.md
@@ -15,7 +15,7 @@
 ## AI Planning Prompt
 
 ### Planning Prompt (Gemini 3.1 Pro High — Planning Mode)
-```text
+```
 Read these files before responding:
 - AGENTS.md
 - docs/sprint/sprint-16-brief.md
@@ -35,7 +35,7 @@ Do not write code yet. Planning only.
 ```
 
 ### Execution Prompt — Stream 1: Private Repos & OAuth
-```text
+```
 Execute Stream 1 — OAuth scoped access.
 Branch: feature/sprint-16-pro
 
@@ -48,7 +48,7 @@ Commit and push.
 ```
 
 ### Execution Prompt — Stream 2: Shareable Links & Comparisons
-```text
+```
 Execute Stream 2 — Public links.
 Still on branch: feature/sprint-16-pro
 
@@ -71,21 +71,57 @@ Commit, push, create PR.
 
 ---
 
-## Story Details & Definition of Done
+## Story Details
 
 ### Private Repos (S16.1)
-**Done when:**
-- [ ] Users can opt-in to private repo access.
-- [ ] Application securely fetches commits from repos otherwise inaccessible to public APIs.
 
-### Public Links & Comparisions (S16.2-S16.3)
+**Data source:** GitHub REST API with `repo` scope.
+
+**UI:**
+- OAuth permissions explainer and toggle.
+
+**Done when:**
+- [ ] Users can opt into private repo access seamlessly.
+- [ ] Application securely fetches commits from org repos inaccessible to public APIs.
+
+---
+
+### Public Links & Comparisons (S16.2-S16.3)
+
+**Data source:** Local DB boolean fields (`is_public`).
+
 **UI:**
 - Share button automatically copies unique UUID permalink.
+- Comparisons show red/green delta arrows.
+
 **Done when:**
 - [ ] `/summary/:id` page resolves without Auth if marked public.
-- [ ] Trends show red/green arrows based on previous periods.
+- [ ] Trends accurately compute percentage changes against previous periods.
+
+---
+
+## New API Endpoints Needed
+
+```python
+PATCH /history/{id}/public
+# Sets summary to public visibility
+GET /summary/public/{id}
+# Returns public summary without requiring Auth
+```
 
 ---
 
 ## Order of Work
+```text
 OAuth Scope Upgrade → Private API Verify → DB Public Flags → React Unauth Page → Trend Math
+```
+
+---
+
+## Definition of Done
+- [ ] NextAuth perfectly handles conditional `repo` scoping
+- [ ] Summaries can be marked as public natively
+- [ ] Unauthenticated `/summary/:id` works
+- [ ] Comparison math completes without floating-point errors
+- [ ] All tests pass
+- [ ] PR merged

--- a/docs/sprint/sprint-17-brief.md
+++ b/docs/sprint/sprint-17-brief.md
@@ -16,7 +16,7 @@
 ## AI Planning Prompt
 
 ### Planning Prompt (Gemini 3.1 Pro High — Planning Mode)
-```text
+```
 Read these files before responding:
 - AGENTS.md
 - docs/sprint/sprint-17-brief.md
@@ -36,7 +36,7 @@ Do not write code yet. Planning only.
 ```
 
 ### Execution Prompt — Stream 1: MCP Server Core
-```text
+```
 Execute Stream 1 — MCP Protocol Server.
 Branch: feature/sprint-17-local-mcp
 
@@ -48,7 +48,7 @@ Commit and push.
 ```
 
 ### Execution Prompt — Stream 2: Web Integration
-```text
+```
 Execute Stream 2 — IDE Integrations & Proactive AI.
 Still on branch: feature/sprint-17-local-mcp
 
@@ -75,21 +75,53 @@ Commit, push, create PR.
 
 ---
 
-## Story Details & Definition of Done
+## Story Details
 
 ### MCP Protocol Setup (S17.1-S17.5)
+
 **Architecture:** Python `mcp` pip package using `stdio` transport.
+
 **Done when:**
 - [ ] Users can add `uv run mcp/server.py` to their `claude_desktop_config.json`.
-- [ ] LLM inside IDE can request commit data and write standups automatically.
+- [ ] LLM inside IDE can request commit data and write standups automatically via tools.
+
+---
 
 ### AI Customization (S17.6-S17.7)
+
+**Data source:** Local DB insight aggregation coupled with LLM evaluation.
+
 **UI:**
-- Insights page displays a sidebar block with "AI Notice" suggestions based on anomalies.
+- Insights page displays a sidebar block with "AI Notice" suggestions.
+
 **Done when:**
-- [ ] LLM automatically identifies "unusually high PR cycle time".
+- [ ] LLM automatically processes anomaly metrics into human-readable recommendations.
+- [ ] Users can store and reuse custom instruction prompts natively.
+
+---
+
+## New API Endpoints Needed
+
+```python
+GET /mcp/sse
+# Real-time SSE endpoint for remote MCP connection
+POST /insights/recommendations
+# Triggers AI background scan of user velocity
+```
 
 ---
 
 ## Order of Work
+```text
 MCP Protocol → Server Functions → Testing via Claude Desktop → Proactive AI Gen → Documentation
+```
+
+---
+
+## Definition of Done
+- [ ] `mcp/server.py` implements tool contracts without error
+- [ ] SSE endpoints correctly proxy tool usage over HTTP
+- [ ] Proactive AI recommendation module hooked into Insights
+- [ ] Prompt templates are savable
+- [ ] All tests pass
+- [ ] PR merged

--- a/docs/sprint/sprint-18-brief.md
+++ b/docs/sprint/sprint-18-brief.md
@@ -16,7 +16,7 @@
 ## AI Planning Prompt
 
 ### Planning Prompt (Gemini 3.1 Pro High — Planning Mode)
-```text
+```
 Read these files before responding:
 - AGENTS.md
 - docs/sprint/sprint-18-brief.md
@@ -36,7 +36,7 @@ Do not write code yet. Planning only.
 ```
 
 ### Execution Prompt — Stream 1: Gamification & Year-in-Review
-```text
+```
 Execute Stream 1 — Core data delights.
 Branch: feature/sprint-18-delight
 
@@ -49,7 +49,7 @@ Commit and push.
 ```
 
 ### Execution Prompt — Stream 2: VS Code Extension
-```text
+```
 Execute Stream 2 — IDE extension sidebar.
 Still on branch: feature/sprint-18-delight
 
@@ -72,21 +72,56 @@ Commit, push, create PR.
 
 ---
 
-## Story Details & Definition of Done
+## Story Details
 
 ### Gamification (S18.1-S18.2)
+
 **Data source:** SQL query counting localized consecutive days with `commit_count > 0`.
+
+**UI:**
+- Interactive Year in Review horizontal block scrolling.
+
 **Done when:**
 - [ ] Streak badges correctly ignore weekends (optional setting).
 - [ ] Year in Review groups data by month and generates "Spotify Wrapped" style UI.
 
+---
+
 ### VS Code Extension (S18.3)
+
 **Architecture:** Typescript `vscode-extension` boilerplate utilizing React webview.
+
+**UI:**
+- Config panel for entering standard GitPulse backend endpoint.
+
 **Done when:**
-- [ ] Plugin runs in local VS Code.
+- [ ] Plugin runs cleanly in local VS Code.
 - [ ] Displays summarized standup view directly in sidebar without leaving editor.
 
 ---
 
+## New API Endpoints Needed
+
+```python
+GET /gamification/streak?username=X
+# Returns current and best unbroken streak
+GET /yearly-review?year=2026&username=X
+# Returns grouped analytical review chunks
+```
+
+---
+
 ## Order of Work
+```text
 Streak SQL → Year-in-Review Endpoint → Celebration UI → VS Code Scaffold
+```
+
+---
+
+## Definition of Done
+- [ ] Gamification logic parses commit timelines precisely
+- [ ] Annual review endpoint fetches within latency budgets
+- [ ] UI visualizes annual data without crashes
+- [ ] Extension works locally inside VS Code runtime
+- [ ] All tests pass
+- [ ] PR merged


### PR DESCRIPTION
Reformats new sprint briefs to strictly align with the layout used in sprints 05 through 10. Explicitly restores the Definition of Done checklist section, groups Story Details logically, and aligns headers properly so agents have a single standard to parse.