### PR TITLE
docs: remove localhost from release notes

### DIFF
--- a/docs/releases/v0.5-analytics-dashboard.md
+++ b/docs/releases/v0.5-analytics-dashboard.md
@@ -38,8 +38,7 @@ A high-level metric dashboard providing immediate "at-a-glance" stats:
 
 ## How to Access
 
-Once your local servers are running, navigate to the new route:
-`http://localhost:3000/analytics?username=YOUR_GITHUB_USERNAME`
+The new dashboard is accessible directly from the **Dashboard** link in the header or by navigating to the `/analytics` route on your deployed application (e.g., `gitpulse.vercel.app/analytics?username=YOUR_GITHUB_USERNAME`).
 
 ---
 *GitPulse — Understand your pulse, one commit at a time.*


### PR DESCRIPTION
Cleanup of hardcoded localhost URLs in official release documentation.