### PR TITLE
docs: Add Sprint 22 Brief and Plan

### DIFF
--- a/docs/sprint/sprint-22-brief.md
+++ b/docs/sprint/sprint-22-brief.md
@@ -1,0 +1,26 @@
+# Sprint 22 Brief: Advanced Delivery & Integrations
+
+## 1. Goal
+Expand GitPulse's delivery mechanisms beyond just local markdown files and simple Slack webhooks. This sprint will implement Email delivery via Resend, GitHub Gist publishing, and LLM Tone/Language customization.
+
+## 2. Context
+While the web UI and CLI generate excellent summaries, users want more automated ways to share them with their teams. Currently, only basic Slack delivery is implemented in `api/routers/deliver.py`. We need to flesh out the remaining features originally planned under Epic #115. Additionally, users have requested the ability to change the output language and tone (e.g., formal, casual, pirate) of the AI summaries.
+
+## 3. Scope & Requirements
+
+### Epic 1: Email & Gist Delivery
+- **Email (Resend):** Integrate the Resend SDK in `api/routers/deliver.py`. Expose a `POST /deliver/email` endpoint that takes an email address and summary text, sending a nicely formatted HTML email.
+- **GitHub Gist:** Expose a `POST /deliver/gist` endpoint. Using the user's GitHub OAuth token (or a CLI provided token), create a secret GitHub Gist containing the markdown summary and return the URL.
+
+### Epic 2: Tone & Language Customization
+- **Backend Updates:** Modify `SummariseRequest` in `api/models.py` to accept `tone` and `language` parameters. Update the prompt builder in `gitpulse/core/summarise.py` to instruct the LLM accordingly.
+- **Web UI:** Add dropdowns for Tone (Professional, Casual, Bullet-points, Pirate) and Language (English, Spanish, French, etc.) on the main generation form.
+- **CLI:** Add `--tone` and `--language` flags to `gitpulse generate`.
+
+## 4. Acceptance Criteria
+- [ ] Users can enter an email address in the Web UI to receive their summary via email.
+- [ ] Users can click a "Publish to Gist" button to instantly create a GitHub Gist.
+- [ ] The CLI and Web UI successfully generate summaries in different languages and tones based on user selection.
+
+## 5. Next Steps
+Agent: Read this brief and immediately generate `sprint-22-plan.md` using the standard technical planning format. Wait for user approval before execution.

--- a/docs/sprint/sprint-22-plan.md
+++ b/docs/sprint/sprint-22-plan.md
@@ -1,0 +1,53 @@
+# Sprint 22 Plan: Advanced Delivery & Integrations
+
+## Overview
+This plan details the technical implementation for expanding GitPulse's delivery options (Email via Resend, GitHub Gists) and adding LLM output customization (Tone & Language).
+
+## Phase 1: Tone & Language Customization
+
+### Step 1.1: Core Library Updates
+**File:** `gitpulse/core/summarise.py`
+- Modify `build_prompt(formatted_activity: str, tone: str = "professional", language: str = "English") -> str`.
+- Inject specific instructions into the system prompt directing the LLM to adopt the requested tone and output in the specified language.
+- Update `summarise` to pass these parameters down.
+
+### Step 1.2: CLI Integration
+**File:** `gitpulse/cli/cli.py`
+- Add `--tone` (default: `professional`) and `--language` (default: `English`) options to the `generate` Typer command.
+- Update the TOML config schema (`~/.gitpulse.toml`) to accept default tone and language preferences under the `[defaults]` section.
+
+### Step 1.3: API & Web UI Updates
+**Files:** `api/models.py`, `api/routers/summarise.py`, `web/src/app/page.tsx`
+- Update `SummariseRequest` Pydantic model to include optional `tone` and `language` fields.
+- Update the frontend form to include select dropdowns for Tone and Language, passing them in the POST request to `/summarise`.
+
+## Phase 2: Advanced Delivery Options
+
+### Step 2.1: Email Delivery Integration
+**Files:** `api/models.py`, `api/routers/deliver.py`
+- Create an `EmailDeliverRequest` model (to, summary).
+- Add `resend` to `pyproject.toml` dependencies.
+- Implement `POST /deliver/email` endpoint using the Resend Python SDK. Requires `RESEND_API_KEY`.
+- Format the markdown summary into simple HTML before sending.
+
+### Step 2.2: GitHub Gist Integration
+**Files:** `api/models.py`, `api/routers/deliver.py`
+- Create a `GistDeliverRequest` model (token, summary, is_public).
+- Implement `POST /deliver/gist` endpoint utilizing `httpx` to call the GitHub API (`POST /gists`).
+- Parse the response and return the generated `html_url`.
+
+## Phase 3: Web UI Integration for Delivery
+
+### Step 3.1: Frontend Delivery Modal
+**File:** `web/src/components/delivery-modal.tsx` (New Component)
+- Create a reusable modal/dialog that opens upon clicking "Share".
+- Implement tabs for "Slack", "Email", and "GitHub Gist".
+- **Email Tab:** Input for email address -> triggers `/deliver/email`.
+- **Gist Tab:** Toggle for Private/Public -> triggers `/deliver/gist` using the current NextAuth GitHub session token.
+
+### Step 3.2: Success Feedback
+- Use `toast` notifications to inform the user of successful delivery or errors.
+
+## Phase 4: Validation & Docs
+- **Testing:** Write `pytest` mocks for Resend and GitHub Gist endpoints.
+- **Documentation:** Add `.env` requirements (`RESEND_API_KEY`) to `README.md` and document the new `/deliver` endpoints in `api-contract.md`.


### PR DESCRIPTION
This PR introduces the sprint brief and technical plan for **Sprint 22: Advanced Delivery & Integrations**. This will cover Email (Resend), GitHub Gists, and Tone/Language customization.