### PR TITLE
docs: adopt @AGENTS.md import + fallback pointer template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — gitpulse
 
-This file provides guidance to AI coding agents (Claude Code, Gemini, etc.) when working with code in this repository. `CLAUDE.md` and `GEMINI.md` are 1-line pointers to this file — no content lives there.
+This file provides guidance to AI coding agents (Claude Code, Gemini, etc.) when working with code in this repository. `CLAUDE.md` and `GEMINI.md` are pointers to this file — no content lives there.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,10 @@
-Read `AGENTS.md` in this folder and follow it.
+# CLAUDE.md
+
+All agent instructions for this repository live in [AGENTS.md](AGENTS.md).
+The line below imports it via Claude Code's `@` syntax:
+
+@AGENTS.md
+
+> **Fallback — do not skip:** if your harness did not automatically load the
+> `@AGENTS.md` import above, read `AGENTS.md` now, before doing anything else
+> here. It contains the real rules, structure, and conventions.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,1 +1,10 @@
-Read `AGENTS.md` in this folder and follow it.
+# GEMINI.md
+
+All agent instructions for this repository live in [AGENTS.md](AGENTS.md).
+The line below imports it via Claude Code's `@` syntax:
+
+@AGENTS.md
+
+> **Fallback — do not skip:** if your harness did not automatically load the
+> `@AGENTS.md` import above, read `AGENTS.md` now, before doing anything else
+> here. It contains the real rules, structure, and conventions.


### PR DESCRIPTION
Carries over the pattern from the dotfiles repo: CLAUDE.md/GEMINI.md now use Claude Code's `@AGENTS.md` import plus an explicit fallback line, instead of a bare pointer sentence. Strictly safer (auto-expands in Claude Code, harmless plain text + explicit fallback elsewhere), same content otherwise. Also fixes now-inaccurate '1-line pointer' wording.